### PR TITLE
Restrict example workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   example:


### PR DESCRIPTION
## Summary
- remove unused pull request and issue write permissions from the example workflow
- keep the workflow token limited to read-only repository contents access

## Verification
- actionlint .github/workflows/main.yml
- git diff --check