### PR TITLE
Document Renovate GitHub Actions update policy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>kitsuyui/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Manage GitHub Actions workflow updates with Renovate.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a Renovate package rule for the `github-actions` manager.
- Group GitHub Actions workflow updates under a clear "GitHub Actions" update policy.

## Validation

- `ruby -rjson -e 'JSON.parse(File.read(".github/renovate.json5"))'`
- `git diff --check`
