### PR TITLE
Bound workflow job runtime

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -12,5 +12,6 @@ permissions:
 jobs:
   update-gitignore:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   example:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Add explicit job timeouts to pull request checks and the scheduled gitignore update workflow.
- Use shorter limits for checkout, spellcheck, and example jobs, with a slightly longer limit for the scheduled gitignore update job.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check origin/main...HEAD`