### PR TITLE
Track gibo version with a Renovate custom manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,21 @@
   "extends": [
     "local>kitsuyui/renovate-config"
   ],
+  "customManagers": [
+    {
+      // Track the gibo binary version pinned as a shell literal in action.yml.
+      // The pattern matches the line preceded by a `# renovate:` hint, so the
+      // depName and datasource live next to the version they describe and any
+      // future shell-pinned dependency can opt in by adding the same hint.
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)action\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "# renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+version=(?<currentValue>v?[0-9][0-9A-Za-z.+-]*)"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "description": "Manage GitHub Actions workflow updates with Renovate.",
@@ -10,6 +25,16 @@
         "github-actions"
       ],
       "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Group updates to the gibo binary pinned in action.yml.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "simonwhitaker/gibo"
+      ],
+      "groupName": "gibo"
     }
   ]
 }

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,8 @@ runs:
         tmpdir=$(mktemp -d)
         trap 'rm -rf "${tmpdir}"' EXIT
         cd "${tmpdir}"
-        version=v3.0.7
+        # renovate: datasource=github-releases depName=simonwhitaker/gibo
+        version=v3.0.22
         executable=gibo
         case "${RUNNER_OS}-${RUNNER_ARCH}" in
           Linux-X64)


### PR DESCRIPTION
## Summary

- Add a Renovate `customManagers` regex entry that scans `action.yml` for a `# renovate:` hint line above `version=...`, so the gibo binary version (currently a shell literal) becomes visible to Renovate.
- Group the resulting PRs under a `gibo` group via `packageRules`.
- Bump the pinned binary from `v3.0.7` (Aug 2023) to `v3.0.22` (May 2026) so Renovate has a current baseline to compare future releases against.

## Why

The `version=vX.Y.Z` line in `action.yml` lives inside a composite action's shell step, which is not a surface any standard Renovate manager understands. Without a custom manager, the only way the pinned version moves is a maintainer editing `action.yml` by hand. The upstream `simonwhitaker/gibo` repo had published 15 releases between the old pin (`v3.0.7`) and HEAD, and none of them produced a PR here.

The hint-driven regex pattern keeps `depName` and `datasource` next to the version they describe, so the rule generalizes: any future shell-pinned dependency can opt in by adding the same `# renovate:` comment, without growing the Renovate config.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, observe Renovate's next dry-run / scheduled run: confirm that the `gibo` group is detected and that `simonwhitaker/gibo` shows up under the `version=` line. (Renovate will not open a fresh PR until the next upstream release; the bump in this PR aligns the baseline to `v3.0.22`.)