### PR TITLE
Add inputs, outputs, and cache guidance for the boilerplates database

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,49 @@
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v4
 - uses: gitignore-in/install-gibo@main
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `version` | (action pin) | gibo release tag (e.g. `v3.0.22`). Leave empty to use the version pinned by the action. |
+| `update` | `'true'` | Run `gibo update` after install. Set to `'false'` to skip the unconditional database refresh, e.g. when caching `~/.gitignore-boilerplates` externally. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `version` | gibo release tag that was installed. |
+| `bin-dir` | Directory containing the gibo executable (already on `PATH`). |
+| `boilerplates-dir` | Directory where gibo stores its boilerplates database (e.g. `$HOME/.gitignore-boilerplates`). |
+
+## Caching the boilerplates database
+
+`gibo update` clones / pulls `simonwhitaker/gitignore-boilerplates` on every run. Pair the action with `actions/cache` and `update: 'false'` to keep that database across runs:
+
+```yaml
+steps:
+- uses: actions/checkout@v4
+
+- id: gibo
+  uses: gitignore-in/install-gibo@main
+  with:
+    update: 'false'
+
+- id: gibo-cache
+  uses: actions/cache@v4
+  with:
+    path: ${{ steps.gibo.outputs.boilerplates-dir }}
+    key: gibo-boilerplates-${{ steps.gibo.outputs.version }}-${{ github.run_id }}
+    restore-keys: |
+      gibo-boilerplates-${{ steps.gibo.outputs.version }}-
+
+- if: steps.gibo-cache.outputs.cache-hit != 'true'
+  run: gibo update
+  shell: bash
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -5,19 +5,54 @@ branding:
   icon: folder-minus
   color: white
 
-inputs: {}
-outputs: {}
+inputs:
+  version:
+    description: |
+      gibo release tag to install. Leave empty to use the version pinned
+      by the action (kept up to date by the Renovate custom manager).
+      Override to install a different release.
+    required: false
+    default: ''
+  update:
+    description: |
+      Whether to run `gibo update` after installing the binary. Set to
+      'false' when the caller restores `~/.gitignore-boilerplates` from
+      `actions/cache` and wants to keep the cached database instead of
+      unconditionally pulling upstream changes.
+    required: false
+    default: 'true'
+
+outputs:
+  version:
+    description: gibo release tag that was installed.
+    value: ${{ steps.install.outputs.version }}
+  bin-dir:
+    description: |
+      Directory containing the installed gibo executable. Already added
+      to GITHUB_PATH; exposed so callers can reference it from
+      `actions/cache` keys or other tooling.
+    value: ${{ steps.install.outputs.bin-dir }}
+  boilerplates-dir:
+    description: |
+      Directory where gibo stores its boilerplates database (the target
+      of `gibo update`). Useful as the `path` of an `actions/cache` step
+      that caches the database across runs.
+    value: ${{ steps.install.outputs.boilerplates-dir }}
 
 runs:
   using: composite
   steps:
-    - run: |
+    - id: install
+      run: |
         set -euo pipefail
         tmpdir=$(mktemp -d)
         trap 'rm -rf "${tmpdir}"' EXIT
         cd "${tmpdir}"
         # renovate: datasource=github-releases depName=simonwhitaker/gibo
         version=v3.0.22
+        if [ -n "${INPUT_VERSION}" ]; then
+          version="${INPUT_VERSION}"
+        fi
         executable=gibo
         case "${RUNNER_OS}-${RUNNER_ARCH}" in
           Linux-X64)
@@ -64,9 +99,33 @@ runs:
             unzip -q "${target}"
             ;;
         esac
-        mkdir -p "${RUNNER_TEMP}/gibo/bin"
-        cp "${executable}" "${RUNNER_TEMP}/gibo/bin/${executable}"
-        chmod +x "${RUNNER_TEMP}/gibo/bin/${executable}"
-        echo "${RUNNER_TEMP}/gibo/bin" >> "${GITHUB_PATH}"
-        "${RUNNER_TEMP}/gibo/bin/${executable}" update
+        bin_dir="${RUNNER_TEMP}/gibo/bin"
+        mkdir -p "${bin_dir}"
+        cp "${executable}" "${bin_dir}/${executable}"
+        chmod +x "${bin_dir}/${executable}"
+        echo "${bin_dir}" >> "${GITHUB_PATH}"
+
+        case "${INPUT_UPDATE}" in
+          true)
+            "${bin_dir}/${executable}" update
+            ;;
+          false)
+            echo "Skipping 'gibo update' because inputs.update=false." >&2
+            ;;
+          *)
+            echo "inputs.update must be 'true' or 'false'; got '${INPUT_UPDATE}'." >&2
+            exit 1
+            ;;
+        esac
+
+        boilerplates_dir="${HOME}/.gitignore-boilerplates"
+
+        {
+          echo "version=${version}"
+          echo "bin-dir=${bin_dir}"
+          echo "boilerplates-dir=${boilerplates_dir}"
+        } >> "${GITHUB_OUTPUT}"
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_UPDATE: ${{ inputs.update }}


### PR DESCRIPTION
## Summary

The action currently fetches the gibo binary and runs `gibo update`
unconditionally on every invocation, with no surface for callers to
negotiate caching. `actions/cache` cannot be wired around
`~/.gitignore-boilerplates` because the action overwrites the
restored database on every run.

This change adds the minimum surface required to make external
caching effective, while preserving the existing call sites:

- `inputs.version`: install a specific gibo release. Empty default
  preserves the action-pinned version managed by the Renovate custom
  manager.
- `inputs.update`: defaults to `'true'`. Setting it to `'false'`
  skips `gibo update` so a cached boilerplates database survives the
  install step.
- `outputs.version`, `outputs.bin-dir`, `outputs.boilerplates-dir`:
  expose enough fact for callers to compose cache keys / paths
  without hard-coding internal layout.
- README: document inputs / outputs and demonstrate pairing
  `update: 'false'` with `actions/cache` plus a fallback
  `gibo update` on cache miss.

The shell literal `version=v3.0.22` is retained for the Renovate
custom manager.

## Test plan

- [ ] Example workflow (`.github/workflows/main.yml`) still passes
      with no inputs (default behaviour unchanged).
- [ ] `actions/cache` example in README runs end-to-end in a
      consumer workflow (manual smoke; not part of CI here).