### PR TITLE
Pin upstream checksums file SHA256 to anchor archive verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,37 @@ steps:
   shell: bash
 ```
 
+## Security model
+
+The action downloads release artifacts from upstream
+[`simonwhitaker/gibo`](https://github.com/simonwhitaker/gibo), which does not
+publish cosign/SLSA signatures. To avoid a self-referential trust chain
+(where both the archive and its checksums file come from the same release
+URL and can be swapped together), the action pins the SHA256 of upstream's
+`checksums.txt` / `checksums.windows.txt` for the **default** `version`
+directly in `action.yml`. The trust anchor is therefore this repository's
+git history (commit review, branch protection) rather than the upstream
+release URL.
+
+What this defends against, for the default `version`:
+
+- Upstream tag rewrite or release artifact replacement after publish
+- TLS / CDN MITM that rewrites both archive and checksums in flight
+
+What it does **not** defend against:
+
+- Upstream compromise that occurs **before** the pinned anchor was committed
+  to this repository
+- A future `version` bump (with matching anchor update) merged into this
+  repository under a compromised review process
+
+When you set `inputs.version` to anything other than the action's pinned
+default, the action falls back to the original self-referential verification
+(both files trusted because they were fetched from the same release URL),
+and prints a warning on stderr. Pinning a non-default `version` does **not**
+disable archive verification — `sha256sum --check` still runs against the
+downloaded `checksums` file — but the anchor step is skipped.
+
 ## License
 
 MIT

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,15 @@ runs:
         cd "${tmpdir}"
         # renovate: datasource=github-releases depName=simonwhitaker/gibo
         version=v3.0.22
+        # Anchor SHA256 of the upstream release's checksums files at the
+        # pinned `version` above. Pinning these in this repo's git history
+        # moves the trust anchor from "same release URL" to this commit's
+        # review trail, defending against upstream tag rewrite, release
+        # artifact replacement, and TLS MITM. Must be updated whenever
+        # `version` changes; see README.md (Security model).
+        checksums_txt_sha256=80f59fbfd31eac67bf7a3839909b65b28795594304dac5bae8611db0647c5d67
+        checksums_windows_txt_sha256=8f41f9ad8d3f95520f23f2589eae9747f3599c5d682d9a90c2063b617787ee16
+        default_version="${version}"
         if [ -n "${INPUT_VERSION}" ]; then
           version="${INPUT_VERSION}"
         fi
@@ -58,27 +67,33 @@ runs:
           Linux-X64)
             target="gibo_Linux_x86_64.tar.gz"
             checksums="checksums.txt"
+            checksums_anchor="${checksums_txt_sha256}"
             ;;
           Linux-ARM64)
             target="gibo_Linux_arm64.tar.gz"
             checksums="checksums.txt"
+            checksums_anchor="${checksums_txt_sha256}"
             ;;
           macOS-X64)
             target="gibo_Darwin_x86_64.tar.gz"
             checksums="checksums.txt"
+            checksums_anchor="${checksums_txt_sha256}"
             ;;
           macOS-ARM64)
             target="gibo_Darwin_arm64.tar.gz"
             checksums="checksums.txt"
+            checksums_anchor="${checksums_txt_sha256}"
             ;;
           Windows-X64)
             target="gibo_Windows_x86_64.zip"
             checksums="checksums.windows.txt"
+            checksums_anchor="${checksums_windows_txt_sha256}"
             executable=gibo.exe
             ;;
           Windows-ARM64)
             target="gibo_Windows_arm64.zip"
             checksums="checksums.windows.txt"
+            checksums_anchor="${checksums_windows_txt_sha256}"
             executable=gibo.exe
             ;;
           *)
@@ -89,6 +104,13 @@ runs:
         release_url="https://github.com/simonwhitaker/gibo/releases/download/${version}"
         curl -fsSLO "${release_url}/${target}"
         curl -fsSLO "${release_url}/${checksums}"
+        if [ "${version}" = "${default_version}" ]; then
+          echo "${checksums_anchor}  ${checksums}" | sha256sum --check -
+        else
+          echo "install-gibo: inputs.version='${version}' differs from the action-pinned default '${default_version}'." >&2
+          echo "install-gibo: anchor verification is skipped; the checksums file is trusted self-referentially (same release URL as the archive)." >&2
+          echo "install-gibo: see README.md (Security model) for the implications." >&2
+        fi
         grep -F "  ${target}" "${checksums}" > "${target}.sha256"
         sha256sum --check "${target}.sha256"
         case "${target}" in


### PR DESCRIPTION
## Summary

The previous `sha256sum --check` step was self-referential: both the release archive and the `checksums.txt` it was verified against came from the same upstream release URL, so an attacker able to rewrite that URL (upstream compromise, tag rewrite, in-flight TLS MITM) could swap both files in lockstep and the verification would still pass.

This PR hard-pins the SHA256 of `checksums.txt` and `checksums.windows.txt` for the action-pinned default `version` directly in `action.yml`. The checksums file is now verified against the in-repo anchor before being used to verify the archive, moving the trust anchor from the release URL to this repository's git history.

When `inputs.version` overrides the pinned default, the anchor cannot be known ahead of time. The action falls back to the original self-referential verification and prints a warning. Archive verification via `sha256sum --check` still runs in both paths; only the anchor step is conditional.

A new "Security model" section in `README.md` describes what the verification does and does not defend against, so callers can reason about it explicitly.

## Test plan

- [x] `bash -n` on the inline shell (extracted from action.yml)
- [x] `shellcheck -s bash` on the inline shell (no warnings)
- [x] `typos` (no findings)
- [x] Local end-to-end simulation with `INPUT_VERSION=""` (default) — anchor verify passes, archive verify passes
- [x] Local end-to-end simulation with `INPUT_VERSION=v3.0.21` (override) — anchor verify skipped with warning, archive verify falls back to self-referential and passes
- [ ] CI workflow `Example` (`.github/workflows/main.yml`) green on this branch

## Maintenance note

The `checksums_txt_sha256` / `checksums_windows_txt_sha256` constants must be updated alongside `version`. Renovate's custom manager currently only tracks `version`; updating the anchor remains a manual step until a structural fix extends Renovate (tracked as a separate finding option).