### PR TITLE
Add boilerplates database ref pinning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: test
+    env:
+      BOILERPLATES_REF: 1046d8fba6b42d367da6314c934cddb6bfe5662e
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./
+      - id: gibo
+        uses: ./
+        with:
+          boilerplates-ref: ${{ env.BOILERPLATES_REF }}
+      - name: Check pinned boilerplates database
+        run: |
+          set -euo pipefail
+          test "${BOILERPLATES_COMMIT}" = "${BOILERPLATES_REF}"
+          git -C "${BOILERPLATES_DIR}" rev-parse --verify HEAD
+          gibo dump Python >/tmp/python.gitignore
+        shell: bash
+        env:
+          BOILERPLATES_COMMIT: ${{ steps.gibo.outputs.boilerplates-commit }}
+          BOILERPLATES_DIR: ${{ steps.gibo.outputs.boilerplates-dir }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ steps:
 | Input | Default | Description |
 | --- | --- | --- |
 | `version` | (action pin) | gibo release tag (e.g. `v3.0.22`). Leave empty to use the version pinned by the action. |
-| `update` | `'true'` | Run `gibo update` after install. Set to `'false'` to skip the unconditional database refresh, e.g. when caching `~/.gitignore-boilerplates` externally. |
+| `update` | `'true'` | Run `gibo update` after install. Set to `'false'` to skip the unconditional database refresh, e.g. when caching the boilerplates database externally. |
+| `boilerplates-ref` | `''` | Optional git ref to check out in the boilerplates database after `gibo update`. Use a commit SHA to make later `gibo dump` output reproducible. |
 
 ## Outputs
 
@@ -21,11 +22,34 @@ steps:
 | --- | --- |
 | `version` | gibo release tag that was installed. |
 | `bin-dir` | Directory containing the gibo executable (already on `PATH`). |
-| `boilerplates-dir` | Directory where gibo stores its boilerplates database (e.g. `$HOME/.gitignore-boilerplates`). |
+| `boilerplates-dir` | Directory where gibo stores its boilerplates database, as reported by `gibo root`. |
+| `boilerplates-commit` | Resolved commit of the boilerplates database, when present. |
+
+## Pinning the boilerplates database
+
+By default, `gibo update` follows the current upstream boilerplates database
+HEAD. Pin `boilerplates-ref` to a commit SHA when downstream steps need
+byte-reproducible `gibo dump` output:
+
+```yaml
+steps:
+- uses: actions/checkout@v4
+- id: gibo
+  uses: gitignore-in/install-gibo@main
+  with:
+    boilerplates-ref: 0123456789abcdef0123456789abcdef01234567
+
+- run: |
+    echo "database commit: ${{ steps.gibo.outputs.boilerplates-commit }}"
+    gibo dump Python > .gitignore
+  shell: bash
+```
 
 ## Caching the boilerplates database
 
-`gibo update` clones / pulls `simonwhitaker/gitignore-boilerplates` on every run. Pair the action with `actions/cache` and `update: 'false'` to keep that database across runs:
+`gibo update` clones / pulls the upstream boilerplates database on every run.
+Pair the action with `actions/cache` and `update: 'false'` to keep that
+database across runs:
 
 ```yaml
 steps:

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,19 @@ inputs:
   update:
     description: |
       Whether to run `gibo update` after installing the binary. Set to
-      'false' when the caller restores `~/.gitignore-boilerplates` from
+      'false' when the caller restores the boilerplates database from
       `actions/cache` and wants to keep the cached database instead of
       unconditionally pulling upstream changes.
     required: false
     default: 'true'
+  boilerplates-ref:
+    description: |
+      Optional git ref for the boilerplates database. When set, the
+      action resolves the ref in the `gibo root` directory and checks
+      it out after `gibo update`, making later `gibo dump` output
+      reproducible for the selected database commit.
+    required: false
+    default: ''
 
 outputs:
   version:
@@ -35,9 +43,16 @@ outputs:
   boilerplates-dir:
     description: |
       Directory where gibo stores its boilerplates database (the target
-      of `gibo update`). Useful as the `path` of an `actions/cache` step
-      that caches the database across runs.
+      of `gibo update`, as reported by `gibo root`). Useful as the
+      `path` of an `actions/cache` step that caches the database across
+      runs.
     value: ${{ steps.install.outputs.boilerplates-dir }}
+  boilerplates-commit:
+    description: |
+      Resolved commit of the boilerplates database when the database is
+      present. Empty when the action did not create or restore the
+      database.
+    value: ${{ steps.install.outputs.boilerplates-commit }}
 
 runs:
   using: composite
@@ -137,6 +152,7 @@ runs:
         cp "${executable}" "${bin_dir}/${executable}"
         chmod +x "${bin_dir}/${executable}"
         echo "${bin_dir}" >> "${GITHUB_PATH}"
+        boilerplates_dir="$("${bin_dir}/${executable}" root)"
 
         case "${INPUT_UPDATE}" in
           true)
@@ -151,14 +167,33 @@ runs:
             ;;
         esac
 
-        boilerplates_dir="${HOME}/.gitignore-boilerplates"
+        boilerplates_commit=""
+        if [ -n "${INPUT_BOILERPLATES_REF}" ]; then
+          if [ ! -d "${boilerplates_dir}/.git" ]; then
+            echo "install-gibo: inputs.boilerplates-ref was set, but '${boilerplates_dir}' is not a git repository." >&2
+            echo "install-gibo: run with update='true' or restore the boilerplates database before pinning it." >&2
+            exit 1
+          fi
+
+          if ! boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse --verify "${INPUT_BOILERPLATES_REF}^{commit}" 2>/dev/null); then
+            git -C "${boilerplates_dir}" fetch --tags origin "${INPUT_BOILERPLATES_REF}"
+            boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse --verify "FETCH_HEAD^{commit}")
+          fi
+          git -C "${boilerplates_dir}" checkout --detach "${boilerplates_commit}"
+        fi
+
+        if [ -d "${boilerplates_dir}/.git" ]; then
+          boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse HEAD)
+        fi
 
         {
           echo "version=${version}"
           echo "bin-dir=${bin_dir}"
           echo "boilerplates-dir=${boilerplates_dir}"
+          echo "boilerplates-commit=${boilerplates_commit}"
         } >> "${GITHUB_OUTPUT}"
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_UPDATE: ${{ inputs.update }}
+        INPUT_BOILERPLATES_REF: ${{ inputs.boilerplates-ref }}


### PR DESCRIPTION
Summary:
- Add a `boilerplates-ref` input so callers can pin the gibo boilerplates database to a specific git ref.
- Add a `boilerplates-commit` output and derive the database directory from `gibo root`.
- Cover the pinned database behavior in the example workflow and README.

Verification:
- ruby -ryaml -e 'YAML.load_file("action.yml"); puts "ok"'
- bash -n <(ruby -ryaml -e 'puts YAML.load_file("action.yml").fetch("runs").fetch("steps").first.fetch("run")')
- shellcheck -s bash <(ruby -ryaml -e 'puts YAML.load_file("action.yml").fetch("runs").fetch("steps").first.fetch("run")')
- actionlint
- local composite-action equivalent run with `boilerplates-ref=1046d8fba6b42d367da6314c934cddb6bfe5662e`
- git diff --check
- typos
