### PR TITLE
fix: serialize gibo database updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Use `outputs.bin-dir` from each step to invoke a specific version explicitly.
 
 When multiple jobs run concurrently on a self-hosted runner **sharing the same user
 account**, they share `$HOME/.gitignore-boilerplates`. If two jobs both call this
-action with `update: 'true'` at the same time, both will run `gibo update` against
-that shared directory simultaneously. The `gibo update` command performs a `git clone`
-or `git pull`, which is not safe under concurrent writers — a `.git/index.lock`
-conflict or partial ref state can occur.
+action with `update: 'true'` at the same time, this action serializes shared
+boilerplates database writes with an atomic lock directory next to that database.
+The lock protects `gibo update` and the optional `boilerplates-ref` checkout from
+concurrent `git clone` / `git pull` / `git checkout` writers. If another process
+holds the lock for too long, the action exits with a timeout instead of running an
+unsafe concurrent update.
 
 **Recommended mitigation for self-hosted runners:**
 

--- a/action.yml
+++ b/action.yml
@@ -153,11 +153,17 @@ runs:
         chmod +x "${bin_dir}/${executable}"
         boilerplates_dir="$("${bin_dir}/${executable}" root)"
         created_boilerplates_dir=false
-        if [ ! -e "${boilerplates_dir}" ]; then
-          created_boilerplates_dir=true
-        fi
+        gibo_update_lock_dir=""
+
+        cleanup_gibo_update_lock() {
+          if [ -n "${gibo_update_lock_dir}" ]; then
+            rmdir "${gibo_update_lock_dir}" 2>/dev/null || true
+            gibo_update_lock_dir=""
+          fi
+        }
 
         cleanup_partial_install() {
+          cleanup_gibo_update_lock
           rm -rf "${bin_dir}"
           if [ "${created_boilerplates_dir}" = true ]; then
             rm -rf "${boilerplates_dir}"
@@ -165,16 +171,56 @@ runs:
         }
         trap 'cleanup_partial_install; rm -rf "${tmpdir}"' EXIT
 
+        acquire_boilerplates_lock() {
+          local lock_dir="${boilerplates_dir}.update.lock"
+          local lock_wait_seconds=300
+          local lock_sleep_seconds=2
+          local waited_seconds=0
+
+          while ! mkdir "${lock_dir}" 2>/dev/null; do
+            if [ "${waited_seconds}" -ge "${lock_wait_seconds}" ]; then
+              echo "install-gibo: timed out waiting for gibo update lock: ${lock_dir}" >&2
+              echo "install-gibo: another process may still be updating the shared boilerplates database." >&2
+              exit 1
+            fi
+            if [ "${waited_seconds}" -eq 0 ]; then
+              echo "install-gibo: waiting for gibo update lock: ${lock_dir}" >&2
+            fi
+            sleep "${lock_sleep_seconds}"
+            waited_seconds=$((waited_seconds + lock_sleep_seconds))
+          done
+
+          gibo_update_lock_dir="${lock_dir}"
+        }
+
+        run_gibo_update() {
+          if [ ! -e "${boilerplates_dir}" ]; then
+            created_boilerplates_dir=true
+          fi
+          "${bin_dir}/${executable}" update
+        }
+
         case "${INPUT_UPDATE}" in
           true)
-            "${bin_dir}/${executable}" update
             ;;
           false)
-            echo "Skipping 'gibo update' because inputs.update=false." >&2
             ;;
           *)
             echo "inputs.update must be 'true' or 'false'; got '${INPUT_UPDATE}'." >&2
             exit 1
+            ;;
+        esac
+
+        if [ "${INPUT_UPDATE}" = true ] || [ -n "${INPUT_BOILERPLATES_REF}" ]; then
+          acquire_boilerplates_lock
+        fi
+
+        case "${INPUT_UPDATE}" in
+          true)
+            run_gibo_update
+            ;;
+          false)
+            echo "Skipping 'gibo update' because inputs.update=false." >&2
             ;;
         esac
 
@@ -196,6 +242,7 @@ runs:
         if [ -d "${boilerplates_dir}/.git" ]; then
           boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse HEAD)
         fi
+        cleanup_gibo_update_lock
 
         {
           echo "version=${version}"


### PR DESCRIPTION
## Summary
- add an atomic lock directory around shared boilerplates database writes in `action.yml`
- keep `gibo update` and optional `boilerplates-ref` checkout under the same lock
- update the self-hosted runner concurrency notes in `README.md`

## Verification
- `actionlint`
- `bash -n` on the embedded action script extracted from action.yml
- `git diff --check`

## Notes
- The local ss format/lint/test wrapper currently fails before running repo commands because it cannot find its render_result helper, so the checks above use this repository's available local tooling directly.
