### PR TITLE
feat: emit notice when gibo dump output may be non-deterministic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -244,6 +244,10 @@ runs:
         fi
         cleanup_gibo_update_lock
 
+        if [ "${INPUT_UPDATE}" = true ] && [ -z "${INPUT_BOILERPLATES_REF}" ] && [ -n "${boilerplates_commit}" ]; then
+          echo "::notice::install-gibo: boilerplates-ref is not set; gibo dump output is non-deterministic and may change between runs. To make this run reproducible, set boilerplates-ref: ${boilerplates_commit}"
+        fi
+
         {
           echo "version=${version}"
           echo "bin-dir=${bin_dir}"


### PR DESCRIPTION
## Summary

When `update: 'true'` (default) and `boilerplates-ref` is not set, `gibo update` fetches the upstream boilerplates database HEAD at run time. This means two runs on different days may produce different `gibo dump` output — the non-determinism is silent and easy to miss.

This PR adds a `::notice::` annotation to the action step when the action runs in this non-deterministic mode. The annotation includes the current database commit SHA, giving users the exact value they can copy into `boilerplates-ref` to pin subsequent runs.

## Changes

- `action.yml`: after `cleanup_gibo_update_lock`, emit a `::notice::` annotation when `update=true` and `boilerplates-ref` is unset and the database commit is known.

## Behaviour

- No change to action outputs, inputs, or defaults.
- The annotation fires only when `INPUT_UPDATE=true` (default), `INPUT_BOILERPLATES_REF` is empty, and `boilerplates_commit` is non-empty (i.e. the database was actually created or updated).
- Users who already set `boilerplates-ref` see no change.

## Trade-offs

- The annotation is informational (`::notice::`) rather than a warning or error, so it does not fail CI or require any action from users who intentionally accept non-determinism (e.g. always-update workflows).
- Users who want byte-reproducible output still need to opt in to `boilerplates-ref` manually; this change makes the opt-in opportunity more discoverable.
