### PR TITLE
docs: add Prerequisites section listing required runner tools and network requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,33 @@ steps:
 - uses: gitignore-in/install-gibo@main
 ```
 
+## Prerequisites
+
+The action runs as a composite `shell: bash` step. The runner must provide:
+
+| Tool | Required when | Notes |
+| --- | --- | --- |
+| `bash` | always | Used as the step shell |
+| `curl` | always | Downloads gibo release archive and checksums file from `github.com` |
+| `sha256sum` | always | Verifies archive integrity; must be GNU coreutils `sha256sum` (not macOS `shasum`) |
+| `tar` | Linux / macOS | Extracts the `.tar.gz` archive |
+| `unzip` | Windows | Extracts the `.zip` archive |
+| `git` | `update: 'true'` or `boilerplates-ref` set | `gibo update` and `boilerplates-ref` checkout both invoke `git` |
+
+**Network**: the action contacts `github.com` at two points — to download the gibo
+release archive from `simonwhitaker/gibo` and (when `update: 'true'`) to clone or
+pull `simonwhitaker/gitignore-boilerplates`. Both require outbound HTTPS and git
+transport to `github.com`. Set `update: 'false'` and restore the boilerplates
+database from `actions/cache` to eliminate the second network call.
+
+**Self-hosted runners**: `gibo update` writes `$HOME/.gitignore-boilerplates/`.
+On self-hosted runners the `$HOME` directory persists across jobs; see
+[Parallel jobs on self-hosted runners](#parallel-jobs-on-self-hosted-runners)
+for the lock-based serialization this action provides and the recommended
+caching strategy.
+
+GitHub-hosted runners satisfy all of the above requirements out of the box.
+
 ## Inputs
 
 | Input | Default | Description |


### PR DESCRIPTION
## Summary

Add a **Prerequisites** section to README.md that explicitly lists the runner
tools and network requirements the action depends on but did not previously
document.

## What this adds

A new section between "Usage" and "Inputs" with two parts:

1. **Tool table** — lists each external command (`bash`, `curl`, `sha256sum`,
   `tar`, `unzip`, `git`), when it is required, and a brief note. Calls out
   that `sha256sum` must be GNU coreutils (not macOS `shasum`), which is the
   existing `sha256sum --check` contract.

2. **Network and self-hosted runner notes** — documents that the action
   contacts `github.com` over HTTPS (and git transport when `update: 'true'`),
   and cross-references the existing concurrency / caching guidance for
   self-hosted runners.

The closing sentence ("GitHub-hosted runners satisfy all of the above
requirements out of the box") makes clear that users of GitHub-hosted runners
do not need to take any action.

## What this does not change

No logic or inputs/outputs are modified. The existing "Concurrency notes" and
"Security model" sections are unchanged.

## Verification

- `typos README.md` — no spelling issues
- All existing CI workflows (main.yml, spellcheck.yml) are unaffected
