### PR TITLE
docs: pin README examples to SHA instead of mutable @main ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: gitignore-in/install-gibo@main
+- uses: gitignore-in/install-gibo@16003b5d1278dde15995459d9b4a01b146ec7798  # v0.1.0+
 ```
+
+> **Pinning**: Pin to a specific commit SHA for reproducible, supply-chain-safe usage.
+> `@main` is a mutable ref and may change without notice.
+> Check the [releases page](https://github.com/gitignore-in/install-gibo/releases) for the
+> latest tagged release, or use a commit SHA pointing to the tip of `main`.
 
 ## Prerequisites
 
@@ -62,7 +67,7 @@ byte-reproducible `gibo dump` output:
 steps:
 - uses: actions/checkout@v4
 - id: gibo
-  uses: gitignore-in/install-gibo@main
+  uses: gitignore-in/install-gibo@16003b5d1278dde15995459d9b4a01b146ec7798  # v0.1.0+
   with:
     boilerplates-ref: 0123456789abcdef0123456789abcdef01234567
 
@@ -83,7 +88,7 @@ steps:
 - uses: actions/checkout@v4
 
 - id: gibo
-  uses: gitignore-in/install-gibo@main
+  uses: gitignore-in/install-gibo@16003b5d1278dde15995459d9b4a01b146ec7798  # v0.1.0+
   with:
     update: 'false'
 


### PR DESCRIPTION
## Summary

The README usage examples use `@main`, which is a mutable ref. If any future
commit to `main` introduces a breaking change, consumers using `@main` will
pick it up without warning.

This PR replaces all three `@main` occurrences in usage examples with the current
`main` HEAD SHA (`16003b5d…`), adding a `# v0.1.0+` comment to convey that
this is the post-v0.1.0 tip. A pinning note is added to the basic usage section
to guide readers toward SHA-pinned or release-tagged references.

## Changes

- `README.md`: Replace `@main` with SHA-pinned ref in all three usage examples
- Add a callout block explaining why `@main` is unsafe and directing users to the
  releases page for a tagged release

## Context

Only `v0.1.0` (2023-09-13) exists as a release tag. The current `main` HEAD
has accumulated 34 commits of improvements (SHA verification, cross-platform
support, `set -euo pipefail`, signal-safe cleanup) that consumers using
`@v0.1.0` will not receive.

A follow-up release (`v0.2.0` or a floating `v0` tag) should be published so
that consumers can reference a stable, named entry point instead of a SHA.

## Test plan

- [x] `typos README.md` — no spelling errors
- [x] No functional changes (action.yml unchanged)