### PR TITLE
docs: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Yui KITSU
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

The `README.md` states "License: MIT" but no `LICENSE` file exists in the
repository. As a result:

- GitHub's license auto-detection returns `null` — no license badge appears
  in the "About" card
- `licensee`, SBOM tools, and OSS license scanners report "no license detected"
  even though the intent is MIT, which can block compliance pipelines for
  consumers

## Change

Adds the standard MIT `LICENSE` file (copyright 2023 Yui KITSU), matching the
existing claim in `README.md`.

## Scope

This PR only adds the `LICENSE` file. Other governance documents
(CONTRIBUTING, SECURITY, CODE_OF_CONDUCT) and remaining README improvements
are tracked in separate findings.