### PR TITLE
ci: add multi-platform matrix (ubuntu, macos, windows) to example workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,12 @@ permissions:
 
 jobs:
   example:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
-    name: test
+    name: test (${{ matrix.os }})
     env:
       BOILERPLATES_REF: 1046d8fba6b42d367da6314c934cddb6bfe5662e
     steps:
@@ -23,7 +26,7 @@ jobs:
           set -euo pipefail
           test "${BOILERPLATES_COMMIT}" = "${BOILERPLATES_REF}"
           git -C "${BOILERPLATES_DIR}" rev-parse --verify HEAD
-          gibo dump Python >/tmp/python.gitignore
+          gibo dump Python >"${RUNNER_TEMP}/python.gitignore"
         shell: bash
         env:
           BOILERPLATES_COMMIT: ${{ steps.gibo.outputs.boilerplates-commit }}


### PR DESCRIPTION
## Summary

The example workflow in `.github/workflows/main.yml` previously ran only on `ubuntu-latest` (Linux x64). The action itself supports six platform branches (`action.yml` handles `Linux-X64`, `Linux-ARM64`, `macOS-X64`, `macOS-ARM64`, `Windows-X64`, `Windows-ARM64`), but the CI had no coverage for macOS or Windows runners.

This PR adds a `strategy.matrix.os` to exercise the three main GitHub-hosted runner families, and fixes a path assumption that only held on Linux.

## Changes

- **`.github/workflows/main.yml`**
  - Added `strategy.matrix.os: [ubuntu-latest, macos-latest, windows-latest]`
  - Changed `runs-on: ubuntu-latest` → `runs-on: ${{ matrix.os }}`
  - Changed `name: test` → `name: test (${{ matrix.os }})` for clearer check names per platform
  - Changed `/tmp/python.gitignore` → `"${RUNNER_TEMP}/python.gitignore"` — `/tmp` is not guaranteed on Windows runners; `RUNNER_TEMP` is the portable, runner-provided scratch directory on all platforms

## Notes

- No changes to `action.yml` or the action logic itself.
- The test step already uses `shell: bash`, which GitHub-hosted Windows runners support via Git Bash, so no additional shell configuration is needed.
