### PR TITLE
docs(action): document anchor verification skip when version is overridden

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,10 @@ inputs:
     description: |
       gibo release tag to install. Leave empty to use the version pinned
       by the action (kept up to date by the Renovate custom manager).
-      Override to install a different release.
+      Override to install a different release. Note: when overriding,
+      the checksums anchor verification is skipped — the checksums file
+      is trusted self-referentially (same release URL). See README.md
+      (Security model) for the implications.
     required: false
     default: ''
   update:


### PR DESCRIPTION
## Summary

The `inputs.version.description` field in `action.yml` did not mention
that overriding the pinned version causes the checksums anchor verification
to be skipped.

The runtime stderr warning and the README.md Security model section already
document this behaviour. This PR makes the caveat visible at workflow-authoring
time — in the marketplace, workflow editor, and IDE integrations — so callers
who override `version` without reading the README are aware of the security
trade-off before using the input.

## Change

- `action.yml` `inputs.version.description`: added a note that anchor verification
  is skipped when a non-default version is specified, and points to README.md
  (Security model) for details.

## Verification

- YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- `shellcheck` on the embedded bash script: no findings
- No functional behaviour changed — description text only

## Trade-offs

The note lengthens the description slightly. No API changes; callers are not affected.
