### PR TITLE
fix: fail early with clear error when boilerplates-ref is a bare SHA not in local database

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,12 @@ inputs:
       action resolves the ref in the `gibo root` directory and checks
       it out after `gibo update`, making later `gibo dump` output
       reproducible for the selected database commit.
+
+      Use a tag name or branch name (e.g. `main`, `v1.2.3`). A bare
+      commit SHA only works when it is already present in the local
+      boilerplates database; git servers reject fetches of unadvertised
+      objects, so a bare SHA will fail when the database is empty or
+      was restored from cache without that commit.
     required: false
     default: ''
 
@@ -233,6 +239,12 @@ runs:
           fi
 
           if ! boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse --verify "${INPUT_BOILERPLATES_REF}^{commit}" 2>/dev/null); then
+            if [[ "${INPUT_BOILERPLATES_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "install-gibo: boilerplates-ref '${INPUT_BOILERPLATES_REF}' is a bare commit SHA that is not present in the local database." >&2
+              echo "install-gibo: Git servers reject fetches of unadvertised objects, so bare SHAs cannot be fetched from remote." >&2
+              echo "install-gibo: Use a tag name or branch name, or run with update='true' to populate the database first." >&2
+              exit 1
+            fi
             git -C "${boilerplates_dir}" fetch --tags origin "${INPUT_BOILERPLATES_REF}"
             boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse --verify "FETCH_HEAD^{commit}")
           fi


### PR DESCRIPTION
## Summary

- Updated the `boilerplates-ref` input description in `action.yml` to document that bare commit SHAs only work when the commit is already present in the local boilerplates database.
- Added an early-exit guard in the shell step: when `boilerplates-ref` is a bare 40-character hex SHA that is not resolvable locally, the action now exits with a clear, actionable error message before attempting a `git fetch`.

## Problem

When `boilerplates-ref` is set to a bare commit SHA and that SHA is not in the local boilerplates database (e.g. the database is empty or was restored from cache without that commit), the action attempted:

```
git fetch --tags origin <sha>
```

Git servers reject fetches of unadvertised objects and respond with:

```
fatal: Server does not allow request for unadvertised object
```

The user received this cryptic error with no indication of what `boilerplates-ref` value caused it or how to fix it.

## Fix

Before falling through to the `git fetch`, the shell step now checks whether the unresolvable ref matches the pattern `^[0-9a-f]{40}$`. If it does, it emits three diagnostic lines and exits with a non-zero status:

```
install-gibo: boilerplates-ref '<sha>' is a bare commit SHA that is not present in the local database.
install-gibo: Git servers reject fetches of unadvertised objects, so bare SHAs cannot be fetched from remote.
install-gibo: Use a tag name or branch name, or run with update='true' to populate the database first.
```

Non-SHA refs (tags, branch names) continue to be fetched as before. The input description in `action.yml` was also updated to surface this constraint to users reading the action interface.

## Files Changed

- `action.yml` — description update for `boilerplates-ref` input; bare-SHA guard added to the install shell step.