### PR TITLE
fix: clean up existing boilerplates dir on interrupted update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,7 @@ runs:
         chmod +x "${bin_dir}/${executable}"
         boilerplates_dir="$("${bin_dir}/${executable}" root)"
         created_boilerplates_dir=false
+        modified_boilerplates_dir=false
         gibo_update_lock_dir=""
 
         cleanup_gibo_update_lock() {
@@ -165,7 +166,7 @@ runs:
         cleanup_partial_install() {
           cleanup_gibo_update_lock
           rm -rf "${bin_dir}"
-          if [ "${created_boilerplates_dir}" = true ]; then
+          if [ "${created_boilerplates_dir}" = true ] || [ "${modified_boilerplates_dir}" = true ]; then
             rm -rf "${boilerplates_dir}"
           fi
         }
@@ -197,6 +198,7 @@ runs:
           if [ ! -e "${boilerplates_dir}" ]; then
             created_boilerplates_dir=true
           fi
+          modified_boilerplates_dir=true
           "${bin_dir}/${executable}" update
         }
 
@@ -232,6 +234,7 @@ runs:
             exit 1
           fi
 
+          modified_boilerplates_dir=true
           if ! boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse --verify "${INPUT_BOILERPLATES_REF}^{commit}" 2>/dev/null); then
             git -C "${boilerplates_dir}" fetch --tags origin "${INPUT_BOILERPLATES_REF}"
             boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse --verify "FETCH_HEAD^{commit}")


### PR DESCRIPTION
`cleanup_partial_install` removes the boilerplates directory only when
`created_boilerplates_dir=true`, which is set exclusively when the directory
did not exist before `run_gibo_update`. On subsequent runs the directory
already exists, so `created_boilerplates_dir` stays `false`. If `gibo update`
or a `boilerplates-ref` checkout is interrupted partway through (SIGKILL, disk
full, network drop), the directory is left in a partially-written state and
cleanup does not remove it. The next run re-uses the corrupted git object store
and fails with errors like `corrupted pack` or `bad object`, requiring manual
`rm -rf` of the boilerplates directory.

**Change**: introduce `modified_boilerplates_dir` to track whether any
write-modifying operation has started against the boilerplates directory:

- set to `true` in `run_gibo_update` before invoking `gibo update`
- set to `true` before `git fetch` / `git checkout --detach` in the
  `boilerplates-ref` block
- `cleanup_partial_install` now removes the directory when either
  `created_boilerplates_dir` or `modified_boilerplates_dir` is `true`

On the success path the final `trap` replacement at the end of the script
already prevents `cleanup_partial_install` from running, so this change does
not affect successful installs.

The impact is limited to self-hosted runners where the boilerplates directory
persists between jobs; GitHub-hosted runners receive a clean VM for each job.
