### PR TITLE
fix: validate version format before URL and path construction

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,12 @@ runs:
         if [ -n "${INPUT_VERSION}" ]; then
           version="${INPUT_VERSION}"
         fi
+        # Guard against path traversal (../) and URL-special characters in version.
+        if ! printf '%s' "${version}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          printf 'install-gibo: invalid version format: %s\n' "${version}" >&2
+          printf 'install-gibo: version must be a release tag like v3.0.22 (v<major>.<minor>.<patch>)\n' >&2
+          exit 1
+        fi
         executable=gibo
         case "${RUNNER_OS}-${RUNNER_ARCH}" in
           Linux-X64)


### PR DESCRIPTION
## Summary

`inputs.version` was passed directly to URL construction and path construction without format validation:

- `release_url="https://github.com/.../releases/download/${version}"` — URL-special characters in `version` (e.g. `#`, `?`, `%`) could alter the request URL silently
- `bin_dir="${RUNNER_TEMP}/gibo/${version}/bin"` — a value like `v3.0.22/../../evil` would resolve outside `$RUNNER_TEMP`

This adds a format check immediately after `version` is resolved from `INPUT_VERSION`, rejecting any value that does not match `v<major>.<minor>.<patch>`:

```bash
if ! printf '%s' "${version}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
  printf 'install-gibo: invalid version format: %s\n' "${version}" >&2
  printf 'install-gibo: version must be a release tag like v3.0.22 (v<major>.<minor>.<patch>)\n' >&2
  exit 1
fi
```

All known gibo releases (`v3.0.22`, `v3.0.21`, …) match this pattern.

## Verification

- The default pinned version (`v3.0.22`) passes the check unconditionally.
- A caller supplying `v3.0.22` or `v3.0.21` passes.
- A caller supplying `v3.0.22/../../evil` or `v3.0.22#frag` exits early with a clear error message.
- `typos` spell checker: no issues.

## Trade-offs

The regex requires exactly `v<major>.<minor>.<patch>`. If upstream gibo ever publishes a release with a pre-release suffix (e.g. `v3.1.0-rc1`), callers using that tag would get a validation error. The pattern can be relaxed at that point if needed.
