### PR TITLE
fix(trap): register bin_dir cleanup immediately after mkdir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -149,6 +149,7 @@ runs:
         esac
         bin_dir="${RUNNER_TEMP}/gibo/${version}/bin"
         mkdir -p "${bin_dir}"
+        trap 'rm -rf "${bin_dir}" "${tmpdir}"' EXIT
         cp "${executable}" "${bin_dir}/${executable}"
         chmod +x "${bin_dir}/${executable}"
         boilerplates_dir="$("${bin_dir}/${executable}" root)"


### PR DESCRIPTION
## Summary

Between `mkdir -p "${bin_dir}"` and the `trap 'cleanup_partial_install' EXIT` registration a few lines later, three operations that can fail run under `set -euo pipefail`:

```bash
mkdir -p "${bin_dir}"
cp "${executable}" "${bin_dir}/${executable}"   # can fail: disk full, permission
chmod +x "${bin_dir}/${executable}"              # can fail: read-only filesystem
boilerplates_dir="$("${bin_dir}/${executable}" root)"  # can fail: gibo binary error
# ... cleanup function definitions ...
trap 'cleanup_partial_install; rm -rf "${tmpdir}"' EXIT  # <-- full trap registered here
```

If any of those operations exits, only the initial `trap 'rm -rf "${tmpdir}"' EXIT` (set at the top of the script) is active at that point. `tmpdir` is cleaned up, but `bin_dir` is leaked.

This is asymmetric with `tmpdir`, which gets its trap registered immediately after `mktemp -d`.

## Fix

Add one line immediately after `mkdir -p "${bin_dir}"`:

```bash
trap 'rm -rf "${bin_dir}" "${tmpdir}"' EXIT
```

This intermediate trap covers `bin_dir` during the window before `cleanup_partial_install` is registered. When `cleanup_partial_install` is registered a few lines later it supersedes this trap with the full lifecycle-aware cleanup (which also handles `boilerplates_dir` if it was created).

On the success path, the final trap reset at the end of the script (`trap 'rm -rf "${tmpdir}"' EXIT`) restores cleanup to tmpdir only — `bin_dir` is intentionally kept because it has been added to `GITHUB_PATH`.

## Changed files

- `action.yml` — one-line addition of intermediate trap after `mkdir -p "${bin_dir}"`

## Verification

- The existing CI example workflow tests a normal install path; `bin_dir` cleanup is only relevant on failure paths.
- `typos` spell check passes locally.
- The trap sequence is: initial (tmpdir) → intermediate (bin_dir + tmpdir) → full (cleanup_partial_install) → success (tmpdir only). Each transition is a complete replacement, no accumulation.

## Trade-offs

None significant. The intermediate trap is replaced before any of the cleanup-heavy code runs, so it adds no overhead to the success path.
