### PR TITLE
fix(lock): detect and remove stale lock dir on ungraceful exit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,7 @@ runs:
 
         cleanup_gibo_update_lock() {
           if [ -n "${gibo_update_lock_dir}" ]; then
-            rmdir "${gibo_update_lock_dir}" 2>/dev/null || true
+            rm -rf "${gibo_update_lock_dir}" 2>/dev/null || true
             gibo_update_lock_dir=""
           fi
         }
@@ -174,10 +174,28 @@ runs:
         acquire_boilerplates_lock() {
           local lock_dir="${boilerplates_dir}.update.lock"
           local lock_wait_seconds=300
+          local lock_stale_seconds=600
           local lock_sleep_seconds=2
           local waited_seconds=0
+          local owner_pid="" owner_ts=0 now=0
 
           while ! mkdir "${lock_dir}" 2>/dev/null; do
+            # Detect and remove a stale lock left by a process that was
+            # killed without running its EXIT trap (e.g. SIGKILL, OOM
+            # killer, or runner timeout-minutes enforcement).
+            if [ -f "${lock_dir}/pid_ts" ]; then
+              read -r owner_pid owner_ts 2>/dev/null < "${lock_dir}/pid_ts" || true
+              owner_pid="${owner_pid:-}"
+              owner_ts="${owner_ts:-0}"
+              now=$(date +%s 2>/dev/null) || now=0
+              if { [ -n "${owner_pid}" ] && ! kill -0 "${owner_pid}" 2>/dev/null; } ||
+                 { [ "${now}" -gt 0 ] && [ "${owner_ts}" -gt 0 ] &&
+                   [ "$(( now - owner_ts ))" -ge "${lock_stale_seconds}" ]; }; then
+                echo "install-gibo: removing stale lock (owner: ${owner_pid:-unknown}): ${lock_dir}" >&2
+                rm -rf "${lock_dir}" 2>/dev/null || true
+                continue
+              fi
+            fi
             if [ "${waited_seconds}" -ge "${lock_wait_seconds}" ]; then
               echo "install-gibo: timed out waiting for gibo update lock: ${lock_dir}" >&2
               echo "install-gibo: another process may still be updating the shared boilerplates database." >&2
@@ -190,6 +208,7 @@ runs:
             waited_seconds=$((waited_seconds + lock_sleep_seconds))
           done
 
+          printf '%s %s\n' "$$" "$(date +%s)" > "${lock_dir}/pid_ts" 2>/dev/null || true
           gibo_update_lock_dir="${lock_dir}"
         }
 


### PR DESCRIPTION
## Problem

The `mkdir`-based lock (`${boilerplates_dir}.update.lock`) is abandoned
when the process is killed without running its `EXIT` trap — e.g. via
`SIGKILL`, OOM killer, or GitHub Actions `timeout-minutes` enforcement.

On self-hosted runners (where the runner directory persists between jobs)
the orphaned lock causes all subsequent jobs that set `update: true` or
`boilerplates-ref:` to wait 300 s and then fail. Recovery requires a
manual `rmdir` of the lock directory.

## Changes

**`cleanup_gibo_update_lock`** — switch `rmdir` to `rm -rf`

The new code writes a `pid_ts` file inside the lock directory. `rmdir`
would silently fail on a non-empty directory; `rm -rf` ensures the
entire lock directory is removed on the normal exit path.

**`acquire_boilerplates_lock`** — staleness check before the wait loop

When the lock already exists, the new logic checks for staleness before
blocking:

- **PID liveness** (`kill -0`): if the owning PID recorded in
  `${lock_dir}/pid_ts` is no longer alive, the lock is removed and
  acquisition is retried immediately.
- **Age fallback** (`date +%s`): if the lock timestamp is ≥
  `lock_stale_seconds` (600 s) old, the lock is removed regardless of
  PID liveness. This covers platforms where `kill -0` is unreliable
  (e.g. Windows self-hosted runners with Git Bash).

On successful acquisition, the action writes `"$$ $(date +%s)"` to
`${lock_dir}/pid_ts` so the next waiter can evaluate both conditions.

**Backward compatibility**: locks created by previous versions of the
action (no `pid_ts` file) skip the staleness check and fall through to
the existing 300-second timeout behaviour unchanged.

## Verification

- YAML syntax: valid (`python3 yaml.safe_load`)
- Bash syntax: `bash -n` passes
- `actionlint` on workflow files: no findings
