### PR TITLE
fix(lock): acquire lock for readers to prevent partial-state reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,14 @@ Use `outputs.bin-dir` from each step to invoke a specific version explicitly.
 ### Parallel jobs on self-hosted runners
 
 When multiple jobs run concurrently on a self-hosted runner **sharing the same user
-account**, they share `$HOME/.gitignore-boilerplates`. If two jobs both call this
-action with `update: 'true'` at the same time, this action serializes shared
-boilerplates database writes with an atomic lock directory next to that database.
-The lock protects `gibo update` and the optional `boilerplates-ref` checkout from
-concurrent `git clone` / `git pull` / `git checkout` writers. If another process
-holds the lock for too long, the action exits with a timeout instead of running an
-unsafe concurrent update.
+account**, they share `$HOME/.gitignore-boilerplates`. This action serializes access
+to the shared boilerplates database with an atomic lock directory placed next to that
+database. The lock protects against both concurrent writers (`update: 'true'` or
+`boilerplates-ref`) and the case where a writer is mid-checkout while a reader job
+would proceed to `gibo dump`. Any job that finds an existing boilerplates database
+also acquires the lock so that `gibo dump` only runs against a fully consistent
+snapshot. If another process holds the lock for too long, the action exits with a
+timeout instead of running an unsafe concurrent operation.
 
 **Recommended mitigation for self-hosted runners:**
 

--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,7 @@ runs:
             ;;
         esac
 
-        if [ "${INPUT_UPDATE}" = true ] || [ -n "${INPUT_BOILERPLATES_REF}" ]; then
+        if [ "${INPUT_UPDATE}" = true ] || [ -n "${INPUT_BOILERPLATES_REF}" ] || [ -d "${boilerplates_dir}" ]; then
           acquire_boilerplates_lock
         fi
 


### PR DESCRIPTION
## Summary

On self-hosted runners sharing the same user account, `install-gibo` uses a directory lock to serialize writers (`update: true` or `boilerplates-ref`). However, reader jobs (`update: false`, no `boilerplates-ref`) did not acquire the lock. A concurrent writer performing `git checkout --detach` modifies the boilerplates working tree file-by-file (non-atomically), so a reader's subsequent `gibo dump` could observe a mix of old and new template files.

## Change

Extend the lock acquisition condition in `action.yml` to include any job that finds an existing boilerplates directory:

```diff
-if [ "${INPUT_UPDATE}" = true ] || [ -n "${INPUT_BOILERPLATES_REF}" ]; then
+if [ "${INPUT_UPDATE}" = true ] || [ -n "${INPUT_BOILERPLATES_REF}" ] || [ -d "${boilerplates_dir}" ]; then
   acquire_boilerplates_lock
fi
```

A reader now holds the lock for the duration of the action step. By the time the step returns and the caller's `gibo dump` step runs, any in-progress writer has already finished its checkout and released the lock, so `gibo dump` always sees a fully consistent snapshot.

The `README.md` concurrency section is updated to reflect that both readers and writers are protected by the lock.

## Impact

- **Self-hosted runners (shared user account):** read–write race between a writer job and a reader job is eliminated.
- **GitHub-hosted runners:** no change; each job has an isolated VM and the lock path is always unique.
- **Jobs with no existing boilerplates directory:** lock is not acquired (condition unchanged for that case).

## Trade-offs

- Reader jobs now briefly wait for writers before the action step completes. The wait is bounded by the existing 300-second lock timeout.
- No change to API, inputs, or outputs.
