### PR TITLE
ci: add workflow_dispatch and post-merge push triggers

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -1,6 +1,7 @@
 name: Update gitignore file
 
 on:
+  workflow_dispatch:
   schedule:
     # daily at 00:00
     - cron: '0 0 * * *'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Example
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,9 @@
 name: Spellcheck
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Two CI workflow gaps that reduce operational efficiency and post-merge visibility:

1. `gitignore-in.yml` had no `workflow_dispatch` trigger, so maintainers could not manually run the daily gitignore update without waiting for the next scheduled run (00:00 UTC) or making a dummy commit.

2. `main.yml` and `spellcheck.yml` were triggered only on `pull_request`, meaning CI does not re-run after a PR is merged to `main`. This leaves post-merge regressions (e.g., subtle interactions between concurrent PRs, or external changes to the pinned `BOILERPLATES_REF` SHA) undetected until the next PR is raised.

## Changes

- `gitignore-in.yml`: Add `workflow_dispatch` trigger alongside the existing `schedule`.
- `main.yml`: Add `push: branches: [main]` trigger alongside `pull_request`.
- `spellcheck.yml`: Add `push: branches: [main]` trigger alongside `pull_request`.

## Verification

- YAML syntax validated for all three files.
- `actionlint` reports no issues.
- No test suite to run locally (validation is CI-based).

## Trade-offs

Adding the `push` trigger to `main.yml` means the `Example` workflow will run once more per merged PR. The workflow is lightweight (checkout + action test), so the added CI cost is minimal.
