### PR TITLE
fix: warn instead of silently suppress pid_ts write failure in acquire_boilerplates_lock

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -235,7 +235,9 @@ runs:
             waited_seconds=$((waited_seconds + lock_sleep_seconds))
           done
 
-          printf '%s %s\n' "$$" "$(date +%s)" > "${lock_dir}/pid_ts" 2>/dev/null || true
+          if ! printf '%s %s\n' "$$" "$(date +%s)" > "${lock_dir}/pid_ts"; then
+            echo "install-gibo: warning: failed to write lock metadata (${lock_dir}/pid_ts); stale lock detection will be unavailable" >&2
+          fi
           gibo_update_lock_dir="${lock_dir}"
         }
 


### PR DESCRIPTION
## Summary

`acquire_boilerplates_lock()` writes `pid_ts` after acquiring the lock so that waiting processes can detect a stale lock (owner died via SIGKILL). The write was previously suppressed with `2>/dev/null || true`, meaning a failure (disk full, quota, permissions) would silently disable stale detection without any visible signal.

With this change, if the write fails the action logs a warning and continues. The lock is already held (the `mkdir` succeeded), so operation proceeds, but the degraded state is visible in the action log for diagnosis.

## Change

```diff
- printf '%s %s\n' "$$" "$(date +%s)" > "${lock_dir}/pid_ts" 2>/dev/null || true
+ if ! printf '%s %s\n' "$$" "$(date +%s)" > "${lock_dir}/pid_ts"; then
+   echo "install-gibo: warning: failed to write lock metadata (${lock_dir}/pid_ts); stale lock detection will be unavailable" >&2
+ fi
```

## Impact

- No functional change under normal conditions.
- On write failure: previously silent; now emits a warning to stderr and continues.
- The polling loop's stale-detection path (`[ -f "${lock_dir}/pid_ts" ]`) still behaves the same — it simply won't fire if the file was never created.
- A SIGKILL-killed lock holder with a missing `pid_ts` still causes a 300-second wait; this PR makes that scenario diagnosable rather than mysterious.

## Test plan

- [ ] CI passes on all platforms (ubuntu, macos, windows)
- [ ] No change in behavior when `pid_ts` write succeeds (normal path)