### PR TITLE
fix: add 60-second timeout to git fetch for mutable boilerplates-ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -296,7 +296,10 @@ runs:
             # Mutable ref (branch or tag): always fetch from upstream so the
             # action resolves the current ref tip rather than a stale local
             # cache, making gibo dump output consistent across runs.
-            git -C "${boilerplates_dir}" fetch --tags origin "${INPUT_BOILERPLATES_REF}"
+            # timeout 60: mirrors the --max-time 30 used for curl downloads;
+            # git has no built-in command-level timeout, so we wrap the call to
+            # prevent a TCP hang from blocking the job for hours.
+            timeout 60 git -C "${boilerplates_dir}" fetch --tags origin "${INPUT_BOILERPLATES_REF}"
             boilerplates_commit=$(git -C "${boilerplates_dir}" rev-parse --verify "FETCH_HEAD^{commit}")
           fi
           git -C "${boilerplates_dir}" checkout --detach "${boilerplates_commit}"


### PR DESCRIPTION
## Summary

Add a 60-second wall-clock timeout to the `git fetch` call used when resolving mutable `boilerplates-ref` values.

## Problem

`action.yml` wraps curl downloads with `--connect-timeout 10 --max-time 30`, but the `git fetch --tags origin` on line 299 has no command-level timeout. A TCP hang (GitHub outage, NAT keepalive timeout, slow self-hosted runner) blocks the job until GitHub Actions' global `timeout-minutes` (default: 360 minutes).

## Change

Wrap the `git fetch` with `timeout 60`:

```bash
timeout 60 git -C "${boilerplates_dir}" fetch --tags origin "${INPUT_BOILERPLATES_REF}"
```

The 60-second value is 2× the `--max-time 30` used for curl to account for git's additional protocol negotiation overhead. `timeout(1)` is part of GNU coreutils and is available on all GitHub-hosted Linux and macOS runners.

## Scope

Only affects the mutable-ref code path (branch name or tag name as `boilerplates-ref`). Full SHA inputs skip the `git fetch` entirely and are unaffected.
