### PR TITLE
ci: expand test matrix to all 6 supported platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,13 @@ jobs:
   ci:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-latest       # Linux x64
+          - ubuntu-24.04-arm    # Linux ARM64
+          - macos-latest        # macOS ARM64 (Apple Silicon)
+          - macos-13            # macOS x64 (Intel)
+          - windows-latest      # Windows x64
+          - windows-11-arm      # Windows ARM64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     name: test (${{ matrix.os }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest       # Linux x64
           - ubuntu-24.04-arm    # Linux ARM64
           - macos-latest        # macOS ARM64 (Apple Silicon)
-          - macos-13            # macOS x64 (Intel)
+          - macos-15-intel      # macOS x64 (Intel)
           - windows-latest      # Windows x64
           - windows-11-arm      # Windows ARM64
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

`action.yml` handles six `RUNNER_OS-RUNNER_ARCH` combinations
(Linux/macOS/Windows × x64/ARM64), but the CI matrix only tested three:

| Runner | Platform | Status |
|--------|----------|--------|
| `ubuntu-latest` | Linux x64 | ✓ tested |
| `macos-latest` | macOS ARM64 (Apple Silicon) | ✓ tested |
| `windows-latest` | Windows x64 | ✓ tested |
| `ubuntu-24.04-arm` | Linux ARM64 | ✗ **untested** |
| `macos-13` | macOS x64 (Intel) | ✗ **untested** |
| `windows-11-arm` | Windows ARM64 | ✗ **untested** |

Platform-specific regressions (binary URL resolution, sha256sum
implementation differences, unzip behaviour, path separators) in the three
untested branches would go undetected until users reported them.

## Change

Expand the `os:` matrix in `.github/workflows/main.yml` to include the three
missing runner labels. All six jobs run on every PR and push to `main`.

## Impact

- CI job count: 3 → 6 (doubles)
- Each job runs within `timeout-minutes: 10`; no change to logic
- All runners are GitHub-hosted; no additional cost for a public repository

## Test plan

- [ ] All 6 matrix jobs pass on this PR
- [ ] Each new platform downloads the correct binary and verifies the checksum
