### PR TITLE
fix: name curl timeout constants with unit suffixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,8 +139,12 @@ runs:
             ;;
         esac
         release_url="https://github.com/simonwhitaker/gibo/releases/download/${version}"
-        curl -fsSLO --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "${release_url}/${target}"
-        curl -fsSLO --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "${release_url}/${checksums}"
+        curl_retry=3
+        curl_retry_delay_seconds=2
+        curl_connect_timeout_seconds=10
+        curl_max_time_seconds=30
+        curl -fsSLO --retry "${curl_retry}" --retry-delay "${curl_retry_delay_seconds}" --connect-timeout "${curl_connect_timeout_seconds}" --max-time "${curl_max_time_seconds}" "${release_url}/${target}"
+        curl -fsSLO --retry "${curl_retry}" --retry-delay "${curl_retry_delay_seconds}" --connect-timeout "${curl_connect_timeout_seconds}" --max-time "${curl_max_time_seconds}" "${release_url}/${checksums}"
         if [ "${version}" = "${default_version}" ]; then
           echo "${checksums_anchor}  ${checksums}" | sha256sum --check -
         else


### PR DESCRIPTION
## Summary

Name the `curl` timeout and retry constants in `action.yml` with explicit unit suffixes, consistent with the `_seconds` naming convention already used for the locking variables in the same file.

**Before:**
```bash
curl -fsSLO --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "${release_url}/${target}"
curl -fsSLO --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "${release_url}/${checksums}"
```

**After:**
```bash
curl_retry=3
curl_retry_delay_seconds=2
curl_connect_timeout_seconds=10
curl_max_time_seconds=30
curl -fsSLO --retry "${curl_retry}" --retry-delay "${curl_retry_delay_seconds}" --connect-timeout "${curl_connect_timeout_seconds}" --max-time "${curl_max_time_seconds}" "${release_url}/${target}"
curl -fsSLO --retry "${curl_retry}" --retry-delay "${curl_retry_delay_seconds}" --connect-timeout "${curl_connect_timeout_seconds}" --max-time "${curl_max_time_seconds}" "${release_url}/${checksums}"
```

## Motivation

The same file uses `lock_wait_seconds`, `lock_stale_seconds`, and `lock_sleep_seconds` — a convention that makes the unit of each value unambiguous at the call site. The two `curl` invocations used bare integer literals, which require checking curl's documentation to confirm that `--retry-delay`, `--connect-timeout`, and `--max-time` all take seconds (not milliseconds). Introducing named constants aligns with the existing style and makes future value changes a single-location edit.

## Verification

- `typos action.yml` — no spelling issues
- Collateral check: clean
- No format or lint commands defined for this repo; CI spellcheck and main workflow will run on PR
