### PR TITLE
chore: override internalChecksFilter to warn for GitHub Actions Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,13 @@
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "GitHub Actions"
+      "groupName": "GitHub Actions",
+      // Override the shared config's internalChecksFilter from "strict" to "warn".
+      // With "strict", a stuck renovate/stability-days PENDING status permanently
+      // blocks the PR (mergeStateStatus: UNSTABLE) even after the minimumReleaseAge
+      // quarantine window has passed and Renovate has not re-evaluated. "warn" keeps
+      // the stability-days signal visible without letting it block auto-merge.
+      "internalChecksFilter": "warn"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Override `internalChecksFilter` from `"strict"` to `"warn"` for GitHub Actions packages in the local Renovate config.

## Problem

The shared `kitsuyui/renovate-config` preset sets `internalChecksFilter: "strict"` for all GitHub Actions packages, which means a `renovate/stability-days` status check that is stuck **PENDING** sets `mergeStateStatus: UNSTABLE` on the PR indefinitely.

Renovate PR #34 has been PENDING on `renovate/stability-days` for 15+ days, even though the 3-day `minimumReleaseAge` window passed long ago and all CI checks (ubuntu/macos/windows test + spellcheck) pass. Because Renovate did not re-run to update the check, the PR has been blocked from merging.

## Change

`.github/renovate.json5`: add `"internalChecksFilter": "warn"` to the existing GitHub Actions package rule.

With `"warn"`, a stuck stability-days check remains visible as a signal but does not set `mergeStateStatus: UNSTABLE`. Renovate PRs for GitHub Actions can proceed to merge once CI passes, even if Renovate has not re-evaluated the stability-days check.

## Trade-offs

- The 3-day quarantine signal is still produced; it is demoted from a merge-blocker to a warning.
- If Renovate is running normally, stability-days transitions to `SUCCESS` before CI finishes and there is no observable difference.
- The risk window where a supply-chain-compromised action could slip through is the same 3-day period; changing from `strict` to `warn` means a stuck check no longer acts as an additional backstop beyond CI.

## Verification

- No local lint/format/test commands (pure config repo).
- `actionlint` on workflow files: no issues.
- Collateral check: clean, no violations.
