### PR TITLE
ci: track typos action by release tag

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -15,6 +15,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check spelling
-        uses: crate-ci/typos@7b04f660f4ee4f048d18fd341887cf28dfbedfe2 # master
+        uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
         # typos is a Source code spell checker
         # https://github.com/crate-ci/typos


### PR DESCRIPTION
## Summary

- Update `.github/workflows/spellcheck.yml` so `crate-ci/typos` tracks the verified `v1.47.2` release instead of the `master` branch.
- Keep the action pinned by commit SHA while changing the Renovate hint from `# master` to `# v1.47.2`.

## Verification

- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `typos`
- Collateral check: clean
- GitHub API confirmed `crate-ci/typos` release `v1.47.2` resolves to commit `37bb98842b0d8c4ffebdb75301a13db0267cef89`.

## Notes

- The existing Renovate digest PR updates the typos SHA but still leaves the workflow tracking `master`; this change switches the tracked source to the release tag.
