### PR TITLE
ci: restrict gitignore-in.yml permissions to job level

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -6,13 +6,14 @@ on:
     # daily at 00:00
     - cron: '0 0 * * *'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-gitignore:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4


### PR DESCRIPTION
## Summary

- Move `permissions: contents: write / pull-requests: write` from workflow level to the `update-gitignore` job level.
- Add `permissions: {}` at workflow level to deny all permissions by default.

## Why

With permissions at workflow level, any future job added to this workflow would inherit `contents: write` and `pull-requests: write` silently. Scoping permissions to the job that actually needs them (`update-gitignore`) follows the principle of least privilege and matches the pattern already used in `main.yml` and `spellcheck.yml`.

## Verification

- `actionlint .github/workflows/gitignore-in.yml`: clean
- Collateral check: clean