### PR TITLE
docs: clarify boilerplates-ref checkout order

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ GitHub-hosted runners satisfy all of the above requirements out of the box.
 | --- | --- | --- |
 | `version` | (action pin) | gibo release tag (e.g. `v3.0.22`). Leave empty to use the version pinned by the action. |
 | `update` | `'true'` | Run `gibo update` after install. Set to `'false'` to skip the unconditional database refresh, e.g. when caching the boilerplates database externally. |
-| `boilerplates-ref` | `''` | Optional git ref to check out in the boilerplates database after `gibo update`. Use a commit SHA to make later `gibo dump` output reproducible. |
+| `boilerplates-ref` | `''` | Optional git ref to check out in the boilerplates database. With `update: 'true'`, the action updates before checkout; with `update: 'false'`, it checks out from the database already present on the runner. Use a commit SHA to make later `gibo dump` output reproducible. |
 
 ## Outputs
 
@@ -61,7 +61,9 @@ GitHub-hosted runners satisfy all of the above requirements out of the box.
 
 By default, `gibo update` follows the current upstream boilerplates database
 HEAD. Pin `boilerplates-ref` to a commit SHA when downstream steps need
-byte-reproducible `gibo dump` output:
+byte-reproducible `gibo dump` output. The checkout runs after any requested
+update, or from the database already present on the runner when `update` is
+`'false'`:
 
 ```yaml
 steps:

--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,11 @@ inputs:
     description: |
       Optional git ref for the boilerplates database. When set, the
       action resolves the ref in the `gibo root` directory and checks
-      it out after `gibo update`, making later `gibo dump` output
-      reproducible for the selected database commit.
+      it out before reporting outputs. With `update: 'true'`, the
+      checkout happens after `gibo update`; with `update: 'false'`,
+      it uses the database already present on the runner. This makes
+      later `gibo dump` output reproducible for the selected database
+      commit.
       A full 40-character commit SHA is resolved from the local
       database without a network fetch; the same SHA always points
       to the same object, so `gibo dump` output is stable across


### PR DESCRIPTION
## Summary
- Clarifies that `boilerplates-ref` checkout happens after `gibo update` only when `update: 'true'` is used.
- Documents that `update: 'false'` checks out from the boilerplates database already present on the runner.
- Keeps the README input table and pinning guidance aligned with `action.yml`.

## Verification
- `actionlint .github/workflows/*.yml`
- `typos action.yml README.md`
- YAML parse for `action.yml` and workflow files
- Extracted composite shell payload from `action.yml` and ran `bash -n -`
- `git diff --check`
- `git status --short` clean
