### PR TITLE
docs: document boilerplates-ref notice behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ steps:
   shell: bash
 ```
 
+When `update` is `'true'` and `boilerplates-ref` is empty, the action emits a
+GitHub Actions notice that includes the resolved `boilerplates-commit`. The
+notice is informational: the action succeeded, but later `gibo dump` output can
+change when the upstream boilerplates database changes. Set `boilerplates-ref`
+to the reported commit, or any other intended boilerplates commit, to make the
+run reproducible and suppress the notice.
+
 ## Caching the boilerplates database
 
 `gibo update` clones / pulls the upstream boilerplates database on every run.


### PR DESCRIPTION
## Summary
- Document when the `boilerplates-ref` GitHub Actions notice is emitted.
- Clarify that the notice is informational and how to suppress it by pinning `boilerplates-ref`.

## Verification
- `actionlint .github/workflows/*.yml`
- YAML parse for `action.yml` and workflow files
- Extracted the composite action shell payload from `action.yml` and ran `bash -n`
- `typos README.md action.yml .github/workflows/*.yml`
- `git diff --check`
