### PR TITLE
ci: rename workflow from "Example" to "CI" and align job key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Example
+name: CI
 on:
   pull_request:
   push:
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  example:
+  ci:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
## Summary

The `.github/workflows/main.yml` workflow has three inconsistent labels for the same entity:
- File name: `main.yml` (generic)
- Workflow `name:`: `Example` (reads as a sample, not real CI)
- Job `name:`: `test (${{ matrix.os }})` (describes what the job does)

Sibling workflows already use role-based names: `gitignore-in.yml` → `Update gitignore file`, `spellcheck.yml` → `Spellcheck`. This PR brings `main.yml` in line.

## Changes

- `name: Example` → `name: CI`
- `jobs.example:` → `jobs.ci:`

No functional changes — trigger conditions, matrix, steps, and action behavior are unchanged.

## Verification

CI will run the renamed workflow on this PR to confirm no regressions.
