### PR TITLE
fix: preserve gibo update results when boilerplates-ref checkout fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -179,6 +179,7 @@ runs:
         modified_boilerplates_dir=false
         gibo_update_lock_dir=""
         install_succeeded=false
+        gibo_update_succeeded=false
 
         cleanup_gibo_update_lock() {
           if [ -n "${gibo_update_lock_dir}" ]; then
@@ -191,7 +192,8 @@ runs:
           cleanup_gibo_update_lock
           if [ "${install_succeeded}" != "true" ]; then
             rm -rf "${bin_dir}"
-            if [ "${created_boilerplates_dir}" = true ] || [ "${modified_boilerplates_dir}" = true ]; then
+            if { [ "${created_boilerplates_dir}" = true ] || [ "${modified_boilerplates_dir}" = true ]; } &&
+               [ "${gibo_update_succeeded}" != "true" ]; then
               rm -rf "${boilerplates_dir}"
             fi
           fi
@@ -245,6 +247,7 @@ runs:
           fi
           modified_boilerplates_dir=true
           "${bin_dir}/${executable}" update
+          gibo_update_succeeded=true
         }
 
         case "${INPUT_UPDATE}" in


### PR DESCRIPTION
## Problem

When `inputs.update: 'true'` and `inputs.boilerplates-ref` is set, if
`gibo update` succeeds but the subsequent `git checkout --detach` fails,
`cleanup_partial_install` deletes the entire boilerplates directory —
including the data that `gibo update` had successfully written.

The root cause is `modified_boilerplates_dir=true`, which is set at the
start of `run_gibo_update()` regardless of whether the update command
ultimately succeeds. The cleanup function cannot distinguish between
"update was attempted and failed (roll back)" and "update succeeded but
a later step failed (preserve)".

Failure conditions that trigger this:
- `inputs.boilerplates-ref` is set to a ref that does not exist locally
  after a successful `gibo update`
- Network / permission errors that fail only the `git checkout` step

## Fix

Add a `gibo_update_succeeded` flag, initialised to `false` and set to
`true` only after the `gibo update` command returns successfully (due to
`set -e`, any non-zero exit skips the assignment). Guard the
boilerplates directory deletion in `cleanup_partial_install` with this
flag: the directory is removed only when the update did not complete
successfully.

Existing behaviour is preserved for every other code path:
- `update=false` with a checkout failure: no change (update never ran)
- `update=true` with a failed update: no change (flag stays `false`)
- `update=true` with no `boilerplates-ref`: unaffected (cleanup not
  reached because `install_succeeded=true`)

## Validation

- Bash syntax check (`bash -n`): pass
- `shellcheck -S warning`: no findings
- Functional tests run via CI (GitHub Actions `main.yml` workflow)