### PR TITLE
feat(outputs): add update-performed and boilerplates-created outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,10 +58,9 @@ outputs:
     value: ${{ steps.install.outputs.bin-dir }}
   boilerplates-dir:
     description: |
-      Directory where gibo stores its boilerplates database (the target
-      of `gibo update`, as reported by `gibo root`). Useful as the
-      `path` of an `actions/cache` step that caches the database across
-      runs.
+      Directory where gibo stores its boilerplates database, as reported
+      by `gibo root`. Set whenever gibo is present; empty when no
+      database exists. Useful as the `path` of an `actions/cache` step.
     value: ${{ steps.install.outputs.boilerplates-dir }}
   boilerplates-commit:
     description: |
@@ -69,6 +68,19 @@ outputs:
       present. Empty when the action did not create or restore the
       database.
     value: ${{ steps.install.outputs.boilerplates-commit }}
+  update-performed:
+    description: |
+      'true' when `gibo update` was invoked in this action run,
+      'false' otherwise (e.g. when `inputs.update` is 'false' or the
+      database was restored from cache). Use this output to conditionally
+      save an `actions/cache` entry only when the database changed.
+    value: ${{ steps.install.outputs.update-performed }}
+  boilerplates-created:
+    description: |
+      'true' when the boilerplates database directory did not exist
+      before this run and was created by `gibo update`. 'false' when
+      the directory already existed or `gibo update` was not invoked.
+    value: ${{ steps.install.outputs.boilerplates-created }}
 
 runs:
   using: composite
@@ -177,6 +189,7 @@ runs:
         boilerplates_dir="$("${bin_dir}/${executable}" root)"
         created_boilerplates_dir=false
         modified_boilerplates_dir=false
+        gibo_update_ran=false
         gibo_update_lock_dir=""
         install_succeeded=false
 
@@ -244,6 +257,7 @@ runs:
             created_boilerplates_dir=true
           fi
           modified_boilerplates_dir=true
+          gibo_update_ran=true
           "${bin_dir}/${executable}" update
         }
 
@@ -317,6 +331,8 @@ runs:
           echo "bin-dir=${bin_dir}"
           echo "boilerplates-dir=${boilerplates_dir}"
           echo "boilerplates-commit=${boilerplates_commit}"
+          echo "update-performed=${gibo_update_ran}"
+          echo "boilerplates-created=${created_boilerplates_dir}"
         } >> "${GITHUB_OUTPUT}"
         echo "${bin_dir}" >> "${GITHUB_PATH}"
       shell: bash


### PR DESCRIPTION
## Summary

Add two new boolean outputs that expose what the action did to the boilerplates database:

- **`update-performed`**: `'true'` when `gibo update` was invoked in this run, `'false'` otherwise. Callers can use this to save an `actions/cache` entry only when the database actually changed, instead of saving unconditionally on every run.
- **`boilerplates-created`**: `'true'` when the database directory was newly created by `gibo update` (did not exist before this run). Useful when callers want to distinguish a fresh clone from a re-run.

Also clarifies the `boilerplates-dir` description to remove the inaccurate phrase `target of `gibo update``. The directory is reported by `gibo root` regardless of whether `gibo update` ran; the old wording implied the output was only relevant when update was enabled.

## Changes

- `action.yml` outputs section: add `update-performed` and `boilerplates-created`
- `action.yml` shell script: add `gibo_update_ran` variable (set to `true` inside `run_gibo_update()`) and write both new outputs to `GITHUB_OUTPUT`
- `action.yml` description fix: `boilerplates-dir` description updated

## Backwards compatibility

Additive only. All existing outputs (`version`, `bin-dir`, `boilerplates-dir`, `boilerplates-commit`) are unchanged. Existing callers that do not reference the new outputs are unaffected.