### PR TITLE
fix: accept uppercase hex SHA in boilerplates-ref detection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -280,7 +280,7 @@ runs:
           fi
 
           modified_boilerplates_dir=true
-          if printf '%s' "${INPUT_BOILERPLATES_REF}" | grep -qE '^[0-9a-f]{40}$'; then
+          if printf '%s' "${INPUT_BOILERPLATES_REF}" | grep -qE '^[0-9a-fA-F]{40}$'; then
             # Immutable SHA: resolve from the local database without a fetch.
             # The same SHA always points to the same object regardless of when
             # or where the action runs, so local resolution is correct.


### PR DESCRIPTION
## Summary

The SHA detection regex `^[0-9a-f]{40}$` in `action.yml:283` only matches lowercase hex characters. When a user passes an uppercase SHA (e.g. `ABCDEF1234567890ABCDEF1234567890ABCDEF12`), the pattern does not match, causing the action to fall through to the mutable-ref branch and execute `git fetch --tags origin <SHA>`. Git servers reject fetches of unadvertised objects, producing a confusing "couldn't find remote ref" error instead of the clear "bare SHA not found in local database" message.

Git itself is case-insensitive for SHA references, so accepting uppercase SHA is the correct behavior.

## Change

- `action.yml:283`: changed `^[0-9a-f]{40}$` to `^[0-9a-fA-F]{40}$`

## Testing

The change affects only the SHA detection branch (line 283). All downstream `git rev-parse` and `git checkout` calls already handle uppercase SHA correctly since Git normalizes case internally.