### PR TITLE
fix(renovate): restore strict internalChecksFilter for GitHub Actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,13 +13,7 @@
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "GitHub Actions",
-      // Override the shared config's internalChecksFilter from "strict" to "warn".
-      // With "strict", a stuck renovate/stability-days PENDING status permanently
-      // blocks the PR (mergeStateStatus: UNSTABLE) even after the minimumReleaseAge
-      // quarantine window has passed and Renovate has not re-evaluated. "warn" keeps
-      // the stability-days signal visible without letting it block auto-merge.
-      "internalChecksFilter": "warn"
+      "groupName": "GitHub Actions"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `.github/renovate.json5` overrode `internalChecksFilter` to `"warn"` for
GitHub Actions package updates, weakening the stability-days quarantine.
With `"warn"`, Renovate auto-merges GitHub Actions updates even while the
stability-days check is still PENDING — which includes the quarantine window
immediately after a new version is published.

This PR removes the override and restores the `"strict"` value inherited from
`local>kitsuyui/renovate-config` (`gha.json5`), which blocks auto-merge until
the stability-days PENDING status clears.

## Changes

- `.github/renovate.json5`: remove `internalChecksFilter: "warn"` override and
  its associated comment block from the GitHub Actions package rule

## Trade-offs

If Renovate's stability-days check gets stuck PENDING after the quarantine
window has passed (the scenario the removed comment described), the GitHub
Actions update PR will remain blocked until Renovate re-evaluates. That is an
operational inconvenience but preserves the intended security posture. A
separate Renovate issue or manual PR close-and-reopen can resolve any stuck
PENDING state.
