### PR TITLE
docs: remove incorrect renovate annotation from CONTRIBUTING.md example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,22 @@
 
 ## Bumping the pinned gibo version
 
-When Renovate (or a manual PR) bumps the `version` in `action.yml`, the two
-SHA256 anchor values must be updated in the same commit.
+When manually bumping the `version` in `action.yml`, the two SHA256 anchor
+values must be updated in the same commit. The gibo version is intentionally
+not Renovate-managed: updating the version and both checksum anchors in the
+same reviewed commit is a security requirement (see `README.md` — Security
+model and `.github/renovate.json5`).
 
 `action.yml` pins:
 
 ```sh
-# renovate: datasource=github-releases depName=simonwhitaker/gibo
 version=v3.0.22
 checksums_txt_sha256=<SHA256 of upstream checksums.txt for v3.0.22>
 checksums_windows_txt_sha256=<SHA256 of upstream checksums.windows.txt for v3.0.22>
 ```
 
-Renovate's custom manager updates only the `version` line. The SHA256 values
-must be updated manually to match the new release.
+All three values (`version`, `checksums_txt_sha256`, `checksums_windows_txt_sha256`)
+must be updated manually in the same commit.
 
 ### Step-by-step
 
@@ -40,10 +42,7 @@ On macOS `sha256sum` is not installed by default; use
 Update `action.yml` with the three new values:
 
 ```sh
-# version line (already done by Renovate if this is a Renovate PR):
 version=<new-version>
-
-# anchor SHA256 values (must be updated manually):
 checksums_txt_sha256=<output of sha256sum checksums.txt, first field only>
 checksums_windows_txt_sha256=<output of sha256sum checksums.windows.txt, first field only>
 ```


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` contained a `# renovate: datasource=github-releases depName=simonwhitaker/gibo` annotation in its code example. This annotation does not exist in `action.yml`, and `.github/renovate.json5` explicitly excludes gibo from Renovate management.

A contributor reading `CONTRIBUTING.md` would see the annotation and either:
- Look for it in `action.yml` (not there, causing confusion)
- Add the annotation thinking it was accidentally removed
- Assume Renovate is managing the gibo version (it is not)

## Changes

- Remove the non-existent `# renovate:` annotation from the code example
- Update the intro sentence from "When Renovate (or a manual PR) bumps..." to "When manually bumping..." to accurately describe the always-manual process
- Add a cross-reference to `renovate.json5` explaining the intentional exclusion
- Remove the misleading "Renovate's custom manager updates only the version line" sentence
- Remove the misleading "# version line (already done by Renovate if this is a Renovate PR)" comment from the step-by-step example

## Verification

- `typos` spellcheck: clean
- No behavior changes; documentation-only fix