### PR TITLE
fix: accept pre-release semver in version validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,9 @@ inputs:
       gibo release tag to install. Leave empty to use the version pinned
       by the action. The pinned default and its checksum anchors are updated
       together by reviewed commits, not by version-only automation. Override
-      to install a different release. Note: when overriding, the checksums
-      anchor verification is skipped — the checksums file is trusted
+      to install a different release. Accepts stable semver (e.g. v3.0.22)
+      and pre-release semver (e.g. v4.0.0-rc.1). Note: when overriding, the
+      checksums anchor verification is skipped — the checksums file is trusted
       self-referentially (same release URL). See README.md (Security model)
       for the implications.
     required: false
@@ -94,9 +95,10 @@ runs:
           version="${INPUT_VERSION}"
         fi
         # Guard against path traversal (../) and URL-special characters in version.
-        if ! printf '%s' "${version}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        # Accepts stable semver (v1.2.3) and pre-release semver (v1.2.3-rc.1).
+        if ! printf '%s' "${version}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
           printf 'install-gibo: invalid version format: %s\n' "${version}" >&2
-          printf 'install-gibo: version must be a release tag like v3.0.22 (v<major>.<minor>.<patch>)\n' >&2
+          printf 'install-gibo: version must be a release tag like v3.0.22 or v4.0.0-rc.1\n' >&2
           exit 1
         fi
         executable=gibo


### PR DESCRIPTION
## Summary

The version validation regex `^v[0-9]+\.[0-9]+\.[0-9]+$` rejected
pre-release semver tags such as `v4.0.0-rc.1` and `v4.0.0-beta.1`.
The inline comment describes the guard as preventing path traversal
and URL-special characters — not as intentionally blocking pre-releases —
so the exclusion appears unintentional.

This PR extends the regex to `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$`
to accept the optional pre-release identifier suffix defined by
semver §9 (`-[dot-separated identifiers of alphanumerics and hyphens]`).

## Changes

- **`action.yml` (validation regex)**: `^v[0-9]+\.[0-9]+\.[0-9]+$` →
  `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$`
- **`action.yml` (error message)**: updated example to include
  `v4.0.0-rc.1` alongside `v3.0.22`
- **`action.yml` (inputs.version description)**: noted that both stable
  and pre-release semver are accepted

## Security property

The extended character set (`[a-zA-Z0-9.-]`) excludes `/` (path traversal),
`?`, `&`, `#`, `%`, and other URL-special characters.
The overall prefix `v[0-9]+\.[0-9]+\.[0-9]+` still enforces a semver-shaped
structure. The security goal stated in the comment is preserved.

## Trade-offs

- **No functional change for existing callers**: stable tags pass the same regex.
- **Pre-release support is opportunistic**: gibo has not published pre-release
  tags to date; this change prepares for the case where it does.
- **Anchor verification is still skipped** for any override version, including
  pre-releases (same behaviour as overriding to a non-default stable tag).
